### PR TITLE
fixed enum handling

### DIFF
--- a/src/main/java/com/sop4j/dbutils/BeanProcessor.java
+++ b/src/main/java/com/sop4j/dbutils/BeanProcessor.java
@@ -280,10 +280,8 @@ public class BeanProcessor {
                     throw new SQLException("Attempted to set an Enum, but class "
                             + params[0].getName() + " was not found: " + e.getMessage());
                 }
-            }
-
-            // Don't call setter if the value object isn't the right type
-            if (this.isCompatibleType(value, params[0])) {
+            } else if (this.isCompatibleType(value, params[0])) {
+                // Don't call setter if the value object isn't the right type
                 setter.invoke(target, new Object[]{value});
             } else {
               throw new SQLException(

--- a/src/test/java/com/sop4j/dbutils/BaseTestCase.java
+++ b/src/test/java/com/sop4j/dbutils/BaseTestCase.java
@@ -39,7 +39,8 @@ public class BaseTestCase extends TestCase {
             "nullObjectTest",
             "nullPrimitiveTest",
             "notDate",
-            "columnProcessorDoubleTest" };
+            "columnProcessorDoubleTest",
+            "enumTest"};
 
     /**
      * The number of columns in the MockResultSet.
@@ -60,7 +61,8 @@ public class BaseTestCase extends TestCase {
             null,
             null,
             new Date(),
-            BigInteger.valueOf(13)};
+            BigInteger.valueOf(13),
+            "ENUM_ZERO"};
 
     private static final Object[] row2 =
         new Object[] {
@@ -73,7 +75,8 @@ public class BaseTestCase extends TestCase {
             null,
             null,
             new Date(),
-            BigInteger.valueOf(13)};
+            BigInteger.valueOf(13),
+            "ENUM_ONE"};
 
     private static final Object[][] rows = new Object[][] { row1, row2 };
 

--- a/src/test/java/com/sop4j/dbutils/EnumTest.java
+++ b/src/test/java/com/sop4j/dbutils/EnumTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2014 SOP4J
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sop4j.dbutils;
+
+/**
+ * Test Enum class.
+ */
+public enum EnumTest {
+    /**
+     * Enum for zero.
+     */
+    ENUM_ZERO,
+
+    /**
+     * Enum for EnumTwo.
+     */
+    ENUM_ONE,
+
+    /**
+     * Enum for Three.
+     */
+    ENUM_TWO;
+}

--- a/src/test/java/com/sop4j/dbutils/TestBean.java
+++ b/src/test/java/com/sop4j/dbutils/TestBean.java
@@ -58,6 +58,13 @@ public class TestBean {
     private double columnProcessorDoubleTest = -1;
 
     /**
+     * the ResultSet will have a string in this column and the
+     * BeanProcessors should convert that to a enum of type EnumTest
+     * and store the value in this property.
+     */
+    private EnumTest enumTest;
+
+    /**
      * Constructor for TestBean.
      */
     public TestBean() {
@@ -144,4 +151,11 @@ public class TestBean {
         columnProcessorDoubleTest = d;
     }
 
+    public EnumTest getEnumTest() {
+        return enumTest;
+    }
+
+    public void setEnumTest(EnumTest enumTest) {
+        this.enumTest = enumTest;
+    }
 }


### PR DESCRIPTION
When enum member variables have explicit setter methods, the current code throws an exception.
There was a bug where an enum was correctly identified and handled as one but right after that it was tried to be handled as a regular data type as well.

Fixed beanprocessor to not treat the field as a regular one when it has already been treated as an enum. changed the if block to an else if block.

Also, updated tests to actually verify that enums are working.
